### PR TITLE
Use sparse-index in docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 target/
 .vscode
+Dockerfile*
+README.md

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -4,12 +4,8 @@ RUN apk add musl-dev
 RUN rustup target add x86_64-unknown-linux-musl
 
 WORKDIR /usr/src/libgen-bot-rs
-COPY Cargo.toml Cargo.lock ./
-RUN mkdir -p src && echo "fn main() {}" > src/main.rs \
-    && cargo fetch --target x86_64-unknown-linux-musl
-
-COPY log.yml .
-COPY src/ ./src/
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+COPY . .
 RUN cargo install --target x86_64-unknown-linux-musl --path .
 
 # Bundle

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -4,12 +4,8 @@ RUN apk add musl-dev
 RUN rustup target add aarch64-unknown-linux-musl
 
 WORKDIR /usr/src/libgen-bot-rs
-COPY Cargo.toml Cargo.lock ./
-RUN mkdir -p src && echo "fn main() {}" > src/main.rs \
-    && cargo fetch --target aarch64-unknown-linux-musl
-
-COPY log.yml .
-COPY src/ ./src/
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+COPY . .
 RUN cargo install --target aarch64-unknown-linux-musl --path .
 
 # Bundle

--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -7,12 +7,8 @@ RUN sh platform.sh
 RUN rustup target add $(cat /.platform)
 
 WORKDIR /usr/src/libgen-bot-rs
-COPY Cargo.toml Cargo.lock ./
-RUN mkdir -p src && echo "fn main() {}" > src/main.rs \
-    && cargo fetch --target $(cat /.platform)
-
-COPY log.yml .
-COPY src/ ./src/
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+COPY . .
 ENV CC_aarch64_unknown_linux_musl=clang
 ENV AR_aarch64_unknown_linux_musl=llvm-ar
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"


### PR DESCRIPTION
With the release of rust 1.68 ([blog announcement](https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html)) sparse registry protocol got stabilized.

This speeds up quite a bit the dependency download times, reducing in 30s the build time of the docker image github action.